### PR TITLE
fix(paths): use relative paths instead of inputs.self

### DIFF
--- a/nixos95/desktop.nix
+++ b/nixos95/desktop.nix
@@ -7,7 +7,7 @@ in {
     wallpaper = lib.mkOption {
       description = "The wallpaper to use";
       type = lib.types.path;
-      default = "${inputs.self}/Ressources/Images/Wallpapers/Wallpaper-1.png";
+      default = ../Ressources/Images/Wallpapers/Wallpaper-1.png;
     };
 
   };

--- a/nixos95/theme.nix
+++ b/nixos95/theme.nix
@@ -1,14 +1,14 @@
 { inputs, config, lib, pkgs, ... }: let
   cfg = config.nixos95;
 
-  theme_dir = "${inputs.self}/Ressources/Themes";
+  root = ../.;
   baseTheme = {
     name = "Chicago95";
-    package = pkgs.callPackage "${theme_dir}/Chicago95/chicago95.nix" { };
+    package = pkgs.callPackage "${root}/Ressources/Themes/Chicago95/chicago95.nix" { };
   };
   iconTheme = {
     name = "Win95_plus";
-    package = pkgs.callPackage "${theme_dir}/Win95_plus/win95_plus.nix" { };
+    package = pkgs.callPackage "${root}/Ressources/Themes/Win95_plus/win95_plus.nix" { };
   };
 in lib.mkIf cfg.enable {
 


### PR DESCRIPTION
when using nixos95 from another flake, the other flake will take over the path of inputs.self and therefore break the paths.

We can fix this by navigating to the root with relative notation and contiuning from there