### PR TITLE
feat: directly include home-manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+example/*/flake.lock
+example/*/hardware-configuration.nix

--- a/README.md
+++ b/README.md
@@ -71,6 +71,17 @@ NixOS-95/
 }
 ```
 
+If you are using home-manager you should also pin your version for Nixos95:
+```
+{
+    inputs = {
+        ...
+        nixos95.inputs.home-manager.follows = "home-manager";
+    };
+    ...
+}
+```
+
 ### 2. Import in Configuration.nix
 
 ```nix

--- a/README.md
+++ b/README.md
@@ -53,6 +53,15 @@ NixOS-95/
   nix.settings.experimental-features = ["nix-command" "flakes" "pipe-operators"]; 
   Enabled
 
+You can initilize a new flake-based configuration with:
+``` 
+# minimal
+nix flake init -t github:Peritia-System/NixOS-95/Dev
+# with home-manager
+nix flake init -t github:Peritia-System/NixOS-95/Dev#home-manager
+```
+
+Or follow the manual installation process:
 
 ### 1. Add Nyx to your flake
 

--- a/example/default/configuration.nix
+++ b/example/default/configuration.nix
@@ -1,0 +1,63 @@
+{ pkgs, ... }: {
+
+  system.stateVersion = "25.05";
+  nix.settings.experimental-features = [
+    "flakes" "nix-command" "pipe-operators"
+  ];
+  
+  nixos95 = {
+    enable = true;
+    user = "alice";
+
+    taskbar = {
+      homeIcon = "whisker-menu-button";
+      battery-plugin.enable = false;
+      applications = [
+        {
+          name = "Files";
+          description = "View and manage local files";
+          icon = "folder_open";
+          exe = "exo-open --launch FileManager";
+        }
+        {
+          name = "Firefox";
+          description = "Browse the Web";
+          pkg = pkgs.firefox;
+          icon = "world";
+        }
+        {
+          name = "Signal";
+          description = "Private Messenger";
+          pkg = pkgs.signal-desktop;
+          icon = "signal";
+        }
+      ];
+    };
+
+    keybinds = {
+      commands = [
+        { key="<Super>l";  exe="xflock4"; }
+      ];
+    };
+  };
+
+  users.users.alice = {
+    isNormalUser = true;
+    initialPassword = "password";
+    home = "/home/alice";
+    createHome = true;
+
+    packages = [
+      pkgs.firefox
+      pkgs.neovim
+      pkgs.signal-desktop
+    ];
+  };
+
+  networking.hostName = "nixos95";
+  networking.networkmanager.enable = true;
+
+  boot.loader.systemd-boot.enable = true;
+  boot.loader.efi.canTouchEfiVariables = true;
+
+}

--- a/example/default/flake.nix
+++ b/example/default/flake.nix
@@ -1,0 +1,25 @@
+{
+  description = "Nixos95 example configuration";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+
+    nixos95 = {
+      url = "github:Peritia-System/NixOS-95";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = { nixpkgs, nixos95, ... }: {
+
+    nixosConfigurations.default = nixpkgs.lib.nixosSystem {
+      system = "x84_64-linux";
+      modules = [
+        nixos95.nixosModules.default
+        ./configuration.nix
+        ./hardware-configuration.nix
+      ];
+    };
+
+  };
+}

--- a/example/home-manager/configuration.nix
+++ b/example/home-manager/configuration.nix
@@ -1,0 +1,66 @@
+{ pkgs, ... }: {
+
+  system.stateVersion = "25.05";
+  nix.settings.experimental-features = [
+    "flakes" "nix-command" "pipe-operators"
+  ];
+  
+  nixos95 = {
+    enable = true;
+    user = "alice";
+
+    taskbar = {
+      homeIcon = "whisker-menu-button";
+      battery-plugin.enable = false;
+      applications = [
+        {
+          name = "Files";
+          description = "View and manage local files";
+          icon = "folder_open";
+          exe = "exo-open --launch FileManager";
+        }
+        {
+          name = "Firefox";
+          description = "Browse the Web";
+          pkg = pkgs.firefox;
+          icon = "world";
+        }
+        {
+          name = "Signal";
+          description = "Private Messenger";
+          pkg = pkgs.signal-desktop;
+          icon = "signal";
+        }
+      ];
+    };
+
+    keybinds = {
+      commands = [
+        { key="<Super>l";  exe="xflock4"; }
+      ];
+    };
+  };
+
+  networking.hostName = "nixos95";
+  users.users.alice = {
+    isNormalUser = true;
+    initialPassword = "password";
+    home = "/home/alice";
+    createHome = true;
+  };
+
+  home-manager.users.alice = {
+    programs.firefox.enable = true;
+    programs.neovim.enable = true;
+
+    home.packages = [
+      pkgs.signal-desktop
+    ];
+  };
+
+  networking.networkmanager.enable = true;
+
+  boot.loader.systemd-boot.enable = true;
+  boot.loader.efi.canTouchEfiVariables = true;
+
+}

--- a/example/home-manager/flake.nix
+++ b/example/home-manager/flake.nix
@@ -1,0 +1,33 @@
+{
+  description = "Nixos95 example configuration";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+
+    home-manager = {
+      url = "github:nix-community/home-manager";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    nixos95 = {
+      url = "github:Peritia-System/NixOS-95";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.home-manager.follows = "home-manager";
+    };
+  };
+
+  outputs = { nixpkgs, nixos95, home-manager, ... }: {
+
+    nixosConfigurations.default = nixpkgs.lib.nixosSystem {
+      system = "x84_64-linux";
+      modules = [
+        nixos95.nixosModules.default
+        home-manager.nixosModules.home-manager
+
+        ./configuration.nix
+        ./hardware-configuration.nix
+      ];
+    };
+
+  };
+}

--- a/flake.lock
+++ b/flake.lock
@@ -22,15 +22,15 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1753250450,
-        "narHash": "sha256-i+CQV2rPmP8wHxj0aq4siYyohHwVlsh40kV89f3nw1s=",
-        "owner": "nixos",
+        "lastModified": 1755615617,
+        "narHash": "sha256-HMwfAJBdrr8wXAkbGhtcby1zGFvs+StOp19xNsbqdOg=",
+        "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fc02ee70efb805d3b2865908a13ddd4474557ecf",
+        "rev": "20075955deac2583bb12f07151c2df830ef346b4",
         "type": "github"
       },
       "original": {
-        "owner": "nixos",
+        "owner": "NixOS",
         "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"

--- a/flake.nix
+++ b/flake.nix
@@ -11,6 +11,30 @@
 
   outputs = { self, nixpkgs, home-manager,... }: {
     nixosModules.default = import ./nixos95 { inherit home-manager; };
+
+    templates.default = {
+      description = "Minimal Nixos-95 configuration";
+      path = ./example/default;
+      welcomeText = ''
+        # Welcome to Nixos95
+
+        Please run `ǹixos-generate-config --dir .` to generate hardware configuration.
+
+        > You can now continue with Step 3 in the README.md
+      '';
+    };
+
+    templates.default = {
+      description = "Minimal Nixos-95 configuration with home-manager";
+      path = ./example/home-manager;
+      welcomeText = ''
+        # Welcome to Nixos95 (with home-manager)
+
+        Please run `nixos-generate-config --dir .` to generate harde configuration.
+
+        > You can now continue with Step 3 in the README.md
+      '';
+    };
   };
 }
 

--- a/flake.nix
+++ b/flake.nix
@@ -3,10 +3,14 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    home-manager = {
+      url = "github:nix-community/home-manager";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
-  outputs = { self, nixpkgs, ... }: {
-    nixosModules.default = import ./nixos95;
+  outputs = { self, nixpkgs, home-manager,... }: {
+    nixosModules.default = import ./nixos95 { inherit home-manager; };
   };
 }
 

--- a/nixos95/core.nix
+++ b/nixos95/core.nix
@@ -2,6 +2,9 @@
   cfg = config.nixos95;
 in lib.mkIf cfg.enable {
 
+
+  home-manager.users.${cfg.user}.home.stateVersion = lib.mkDefault "25.05";
+
   services.xserver = {
     enable = true;
     desktopManager.xfce.enable = true;

--- a/nixos95/default.nix
+++ b/nixos95/default.nix
@@ -1,4 +1,4 @@
-{ config, lib, ...}: let 
+{ home-manager }: { config, lib, ...}: let 
   cfg = config.nixos95;
 in {
 
@@ -14,6 +14,8 @@ in {
   };
 
   imports = [
+    home-manager.nixosModules.home-manager
+
     ./core.nix
     ./desktop.nix
     ./keybinds.nix


### PR DESCRIPTION
In our current approach the user has to include home-manager themselfs in their config. If they dont, they will become weird errors. Additionally some folks might not even use home-manager and I think it would be great if the setup was as easy from them as for the rest.

Therefore I added home-manager as a flake input and included it in our config directly. 
The only _drawback_ is that now someone who includes home-manager themselfs has to pin the home-manager input for Nixos95 (which I also mentioned in the README.