### PR TITLE
docs: cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ NixOS-95/
   Enabled
 
 
-### 1. Add Nyx to your flake
+### 1. Add Nixos95 to your flake and import the module
 
 ```nix
 # flake.nix
@@ -63,79 +63,94 @@ NixOS-95/
     nixos95.url = "github:Peritia-System/NixOS-95/Dev";
     nixos95.inputs.nixpkgs.follows = "nixpkgs";
   }
-  outputs = inputs @ { nixpkgs, nixos95, ... }: {
+  outputs = inputs @ { nixos95, ... }: {
     nixosConfigurations.HOSTNAME = nixpkgs.lib.nixosSystem {
-      modules = [ ./configuration.nix ];
+      modules = [ 
+        nixos95.nixosModules.default
+        ./configuration.nix 
+      ];
     };
   };
 }
 ```
 
-### 2. Import in Configuration.nix
+### 2. Enable modules
 
-```nix
-# configuration.nix
+You can configure Nixos95 under the `nixos95` namespace. For a minimal config just set:
+```
 {
-  imports = [ inputs.self.nixosModules.nixos95 ];
+    nixos95.enable = true;
 }
 ```
 
-### 3. Enable modules
+> Warning: This will activate the xfce desktop manager, as well as lightdm and ssdm as display manager.
+> You might want to disable your other desktop environment to prevent bugs.
+
+If you want to further customize Nixos95 you can use the following config options (given values are the default ones):
 
 ```nix
 {
-  # configuration.nix / or sth imported by the main config
   nixos95 = {
-    enable = true;
-    user = "alex";
+    enable = true; # default is false
+    user = "USERNAME"; # no default set; specifies the user used by home-manager
+
+    wallpaper = ./Resources/Images/Wallpapers/Wallpaper-1.png;
 
     taskbar = {
       homeIcon = "whisker-menu-button";
-      battery-plugin.enable = false;
-      applications = [
-        {
-          name = "Brave";
-          description = "Browse the Web";
-          pkg = pkgs.brave;
-          icon = "world";
-        }
-        {
-          name = "Signal";
-          description = "Private Messenger";
-          pkg = pkgs.signal-desktop;
-          icon = "signal";
-        }
-        {
-          name = "Obsidian";
-          description = "Markdown Editor";
-          exe = "obsidian %u";
-          icon = "obsidian";
-        }
-        {
-          name = "Spotify";
-          description = "Spotify Music";
-          exe = "spotify %U";
-          icon = "spotify";
-        }
-      ];
+      battery-plugin = {
+        enable = true;
+        power_bar = {
+            enabe = true;
+            critical_at = 10;
+            warning_at = 20;
+            color_warning = "rgb(248,228,92)";
+            color_critical = "rgb(237,51,59)";
+            color_loading = "rgb(119,118,123)";
+            color_default = "rgb(143,240,164)";
+        };
+      };
     };
+    applications = [
+      {
+        name = "Files";
+        description = "View and manage local files";
+        icon = "folder_open";
+        exe = "exo-open --launch FileManager";
+      }
+      {
+        name = "Terminal";
+        description = "Run commands";
+        icon = "xfce4-terminal";
+        pkg = pkgs.xfce.xfce4-terminal;
+      }
+      {
+        name = "Browser";
+        description = "Access the world wide web";
+        icon = "firefox";
+        exe = "exo-open --launch WebBrowser";
+      }
+    ];
 
     keybinds = {
       commands = [
+        { key = "<Super>r"; exe = "xfce4-appfinder --collapsed"; }
+        { key = "XF86WWW"; exe = "exo-open --launch WebBrowser"; }
+        { key = "XF86Mail"; exe = "exo-open --launch MailReder"; }
+        { key = "Print"; exe = "xfce4-screenshooter"; }
         { key="<Super>l";  exe="xflock4"; }
       ];
+      xfwm4 = [ ];
     };
   };
-
 }
 ```
 
-4. **Build and switch to the system configuration**:
+### 3. **Build and switch to the system configuration**:
 
-   ```bash
-   sudo NIX_CONFIG="experimental-features = nix-command flakes pipe-operators" nixos-rebuild switch --flake .#default
-   ```
-w
+```bash
+sudo NIX_CONFIG="experimental-features = nix-command flakes pipe-operators" nixos-rebuild switch --flake .#default
+```
 
 ### Experimental Features
 
@@ -147,7 +162,7 @@ They are needed to activate the configuration.
 To enable them in your config set:
 ```nix
 nix.settings.experimental-features = [
-    "flakes" "pipe-operators"
+  "flakes" "pipe-operators"
 ];
 ```
 


### PR DESCRIPTION
A small cleanup of the README. Mainly fixed some typos.

I also changed the example configuration to show all available options so we have them "documented" at least somewhere.