### PR TITLE
fix(templates): use correct name for home-manager template

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -24,7 +24,7 @@
       '';
     };
 
-    templates.default = {
+    templates.home-manager = {
       description = "Minimal Nixos-95 configuration with home-manager";
       path = ./example/home-manager;
       welcomeText = ''


### PR DESCRIPTION
Well that was an upsi